### PR TITLE
Feat/#55 회원 프로필 이미지 조회

### DIFF
--- a/src/main/java/com/dateplan/dateplan/domain/couple/service/CoupleReadService.java
+++ b/src/main/java/com/dateplan/dateplan/domain/couple/service/CoupleReadService.java
@@ -37,14 +37,21 @@ public class CoupleReadService {
 		return coupleRepository.existsByMember1OrMember2(loginMember, loginMember);
 	}
 
-	public void checkAuthorityToTargetMember(Member member, Long targetMemberId, Operation operation) {
+	public void checkAuthorityToTargetMember(Member member, Long targetMemberId,
+		Operation operation) {
 
 		Couple couple = findCoupleByMemberOrElseThrow(member);
 		Long partnerId = couple.getPartnerId(member);
 
-		if (!Objects.equals(member.getId(), targetMemberId) && !Objects.equals(partnerId,
-			targetMemberId)) {
-			throw new NoPermissionException(Resource.MEMBER, operation);
+		if (operation == Operation.READ) {
+			if (!Objects.equals(member.getId(), targetMemberId) && !Objects.equals(partnerId,
+				targetMemberId)) {
+				throw new NoPermissionException(Resource.MEMBER, operation);
+			}
+		} else {
+			if (!Objects.equals(member.getId(), targetMemberId)) {
+				throw new NoPermissionException(Resource.MEMBER, operation);
+			}
 		}
 	}
 

--- a/src/main/java/com/dateplan/dateplan/domain/couple/service/CoupleReadService.java
+++ b/src/main/java/com/dateplan/dateplan/domain/couple/service/CoupleReadService.java
@@ -5,11 +5,7 @@ import com.dateplan.dateplan.domain.couple.entity.Couple;
 import com.dateplan.dateplan.domain.couple.repository.CoupleRepository;
 import com.dateplan.dateplan.domain.member.entity.Member;
 import com.dateplan.dateplan.global.auth.MemberThreadLocal;
-import com.dateplan.dateplan.global.constant.Operation;
-import com.dateplan.dateplan.global.constant.Resource;
-import com.dateplan.dateplan.global.exception.NoPermissionException;
 import com.dateplan.dateplan.global.exception.couple.MemberNotConnectedException;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,22 +33,10 @@ public class CoupleReadService {
 		return coupleRepository.existsByMember1OrMember2(loginMember, loginMember);
 	}
 
-	public void checkAuthorityToTargetMember(Member member, Long targetMemberId,
-		Operation operation) {
+	public Long getPartnerId(Member member){
 
-		Couple couple = findCoupleByMemberOrElseThrow(member);
-		Long partnerId = couple.getPartnerId(member);
-
-		if (operation == Operation.READ) {
-			if (!Objects.equals(member.getId(), targetMemberId) && !Objects.equals(partnerId,
-				targetMemberId)) {
-				throw new NoPermissionException(Resource.MEMBER, operation);
-			}
-		} else {
-			if (!Objects.equals(member.getId(), targetMemberId)) {
-				throw new NoPermissionException(Resource.MEMBER, operation);
-			}
-		}
+		return findCoupleByMemberOrElseThrow(member)
+			.getPartnerId(member);
 	}
 
 	public CoupleInfoServiceResponse getCoupleInfo() {

--- a/src/main/java/com/dateplan/dateplan/domain/couple/service/CoupleReadService.java
+++ b/src/main/java/com/dateplan/dateplan/domain/couple/service/CoupleReadService.java
@@ -4,8 +4,12 @@ import com.dateplan.dateplan.domain.couple.dto.CoupleInfoServiceResponse;
 import com.dateplan.dateplan.domain.couple.entity.Couple;
 import com.dateplan.dateplan.domain.couple.repository.CoupleRepository;
 import com.dateplan.dateplan.domain.member.entity.Member;
-import com.dateplan.dateplan.global.exception.couple.MemberNotConnectedException;
 import com.dateplan.dateplan.global.auth.MemberThreadLocal;
+import com.dateplan.dateplan.global.constant.Operation;
+import com.dateplan.dateplan.global.constant.Resource;
+import com.dateplan.dateplan.global.exception.NoPermissionException;
+import com.dateplan.dateplan.global.exception.couple.MemberNotConnectedException;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +35,17 @@ public class CoupleReadService {
 		Member loginMember = MemberThreadLocal.get();
 
 		return coupleRepository.existsByMember1OrMember2(loginMember, loginMember);
+	}
+
+	public void checkAuthorityToTargetMember(Member member, Long targetMemberId, Operation operation) {
+
+		Couple couple = findCoupleByMemberOrElseThrow(member);
+		Long partnerId = couple.getPartnerId(member);
+
+		if (!Objects.equals(member.getId(), targetMemberId) && !Objects.equals(partnerId,
+			targetMemberId)) {
+			throw new NoPermissionException(Resource.MEMBER, operation);
+		}
 	}
 
 	public CoupleInfoServiceResponse getCoupleInfo() {

--- a/src/main/java/com/dateplan/dateplan/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dateplan/dateplan/domain/member/controller/MemberController.java
@@ -1,5 +1,7 @@
 package com.dateplan.dateplan.domain.member.controller;
 
+import static com.dateplan.dateplan.global.constant.Operation.READ;
+
 import com.dateplan.dateplan.domain.couple.service.CoupleReadService;
 import com.dateplan.dateplan.domain.couple.service.CoupleService;
 import com.dateplan.dateplan.domain.member.dto.ConnectionRequest;
@@ -8,8 +10,11 @@ import com.dateplan.dateplan.domain.member.dto.ConnectionServiceResponse;
 import com.dateplan.dateplan.domain.member.dto.MemberInfoResponse;
 import com.dateplan.dateplan.domain.member.dto.MemberInfoServiceResponse;
 import com.dateplan.dateplan.domain.member.dto.PresignedURLResponse;
+import com.dateplan.dateplan.domain.member.dto.ProfileImageURLResponse;
+import com.dateplan.dateplan.domain.member.dto.ProfileImageURLServiceResponse;
 import com.dateplan.dateplan.domain.member.service.MemberReadService;
 import com.dateplan.dateplan.domain.member.service.MemberService;
+import com.dateplan.dateplan.global.auth.MemberThreadLocal;
 import com.dateplan.dateplan.global.dto.response.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +38,7 @@ public class MemberController {
 	private final CoupleReadService coupleReadService;
 
 	@GetMapping("/me")
-	public ApiResponse<MemberInfoResponse> getCurrentLoginMemberInfo(){
+	public ApiResponse<MemberInfoResponse> getCurrentLoginMemberInfo() {
 
 		MemberInfoServiceResponse serviceResponse = memberReadService.getCurrentLoginMemberInfo();
 		boolean isConnected = coupleReadService.isCurrentLoginMemberConnected();
@@ -43,8 +48,21 @@ public class MemberController {
 		return ApiResponse.ofSuccess(response);
 	}
 
+	@GetMapping("/{member_id}/profile/image")
+	public ApiResponse<ProfileImageURLResponse> getProfileImageURL(
+		@PathVariable("member_id") Long memberId) {
+
+		coupleReadService.checkAuthorityToTargetMember(MemberThreadLocal.get(), memberId, READ);
+
+		ProfileImageURLServiceResponse serviceResponse = memberReadService.getProfileImageURL(
+			memberId);
+
+		return ApiResponse.ofSuccess(serviceResponse.toResponse());
+	}
+
 	@GetMapping("/{member_id}/profile/image/presigned-url")
-	public ApiResponse<PresignedURLResponse> getPresignedURL(@PathVariable("member_id") Long memberId) {
+	public ApiResponse<PresignedURLResponse> getPresignedURL(
+		@PathVariable("member_id") Long memberId) {
 
 		PresignedURLResponse presingedURL = memberService.getPresignedURLForProfileImage(memberId);
 
@@ -70,7 +88,8 @@ public class MemberController {
 	@GetMapping("/{member_id}/connect")
 	public ApiResponse<ConnectionResponse> getConnectionCode(
 		@PathVariable("member_id") Long memberId) {
-		ConnectionServiceResponse connectionServiceResponse = coupleService.getConnectionCode(memberId);
+		ConnectionServiceResponse connectionServiceResponse = coupleService.getConnectionCode(
+			memberId);
 		return ApiResponse.ofSuccess(connectionServiceResponse.toConnectionResponse());
 	}
 

--- a/src/main/java/com/dateplan/dateplan/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dateplan/dateplan/domain/member/controller/MemberController.java
@@ -1,7 +1,5 @@
 package com.dateplan.dateplan.domain.member.controller;
 
-import static com.dateplan.dateplan.global.constant.Operation.READ;
-
 import com.dateplan.dateplan.domain.couple.service.CoupleReadService;
 import com.dateplan.dateplan.domain.couple.service.CoupleService;
 import com.dateplan.dateplan.domain.member.dto.ConnectionRequest;
@@ -52,10 +50,10 @@ public class MemberController {
 	public ApiResponse<ProfileImageURLResponse> getProfileImageURL(
 		@PathVariable("member_id") Long memberId) {
 
-		coupleReadService.checkAuthorityToTargetMember(MemberThreadLocal.get(), memberId, READ);
+		Long partnerId = coupleReadService.getPartnerId(MemberThreadLocal.get());
 
 		ProfileImageURLServiceResponse serviceResponse = memberReadService.getProfileImageURL(
-			memberId);
+			memberId, partnerId);
 
 		return ApiResponse.ofSuccess(serviceResponse.toResponse());
 	}

--- a/src/main/java/com/dateplan/dateplan/domain/member/dto/ProfileImageURLResponse.java
+++ b/src/main/java/com/dateplan/dateplan/domain/member/dto/ProfileImageURLResponse.java
@@ -1,0 +1,12 @@
+package com.dateplan.dateplan.domain.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProfileImageURLResponse {
+
+	private String profileImageURL;
+
+}

--- a/src/main/java/com/dateplan/dateplan/domain/member/dto/ProfileImageURLServiceResponse.java
+++ b/src/main/java/com/dateplan/dateplan/domain/member/dto/ProfileImageURLServiceResponse.java
@@ -1,0 +1,18 @@
+package com.dateplan.dateplan.domain.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProfileImageURLServiceResponse {
+
+	private String profileImageURL;
+
+	public ProfileImageURLResponse toResponse() {
+
+		return ProfileImageURLResponse.builder()
+			.profileImageURL(this.profileImageURL)
+			.build();
+	}
+}

--- a/src/main/java/com/dateplan/dateplan/domain/member/entity/Member.java
+++ b/src/main/java/com/dateplan/dateplan/domain/member/entity/Member.java
@@ -40,7 +40,7 @@ public class Member {
 	private String phone;
 
 	@NotNull
-	@Column(name = "nickname", columnDefinition = "VARCHAR(30)")
+	@Column(name = "nickname", unique = true, columnDefinition = "VARCHAR(30)")
 	private String nickname;
 
 	@Column(name = "birth", columnDefinition = "DATE", updatable = false)

--- a/src/main/java/com/dateplan/dateplan/domain/member/service/MemberReadService.java
+++ b/src/main/java/com/dateplan/dateplan/domain/member/service/MemberReadService.java
@@ -1,6 +1,7 @@
 package com.dateplan.dateplan.domain.member.service;
 
 import com.dateplan.dateplan.domain.member.dto.MemberInfoServiceResponse;
+import com.dateplan.dateplan.domain.member.dto.ProfileImageURLServiceResponse;
 import com.dateplan.dateplan.domain.member.entity.Member;
 import com.dateplan.dateplan.domain.member.repository.MemberRepository;
 import com.dateplan.dateplan.global.auth.MemberThreadLocal;
@@ -41,7 +42,16 @@ public class MemberReadService {
 			.orElseThrow(MemberNotFoundException::new);
 	}
 
-	public MemberInfoServiceResponse getCurrentLoginMemberInfo(){
+	public ProfileImageURLServiceResponse getProfileImageURL(Long memberId) {
+
+		Member findMember = findMemberByIdOrElseThrow(memberId);
+
+		return ProfileImageURLServiceResponse.builder()
+			.profileImageURL(findMember.getProfileImageUrl())
+			.build();
+	}
+
+	public MemberInfoServiceResponse getCurrentLoginMemberInfo() {
 
 		Member loginMember = MemberThreadLocal.get();
 

--- a/src/test/java/com/dateplan/dateplan/controller/member/MemberController/MemberControllerTest.java
+++ b/src/test/java/com/dateplan/dateplan/controller/member/MemberController/MemberControllerTest.java
@@ -27,6 +27,9 @@ import com.dateplan.dateplan.domain.member.dto.ConnectionServiceRequest;
 import com.dateplan.dateplan.domain.member.dto.ConnectionServiceResponse;
 import com.dateplan.dateplan.domain.member.dto.MemberInfoServiceResponse;
 import com.dateplan.dateplan.domain.member.dto.PresignedURLResponse;
+import com.dateplan.dateplan.domain.member.dto.ProfileImageURLServiceResponse;
+import com.dateplan.dateplan.domain.member.entity.Member;
+import com.dateplan.dateplan.global.auth.MemberThreadLocal;
 import com.dateplan.dateplan.global.constant.Gender;
 import com.dateplan.dateplan.global.constant.Operation;
 import com.dateplan.dateplan.global.constant.Resource;
@@ -34,6 +37,7 @@ import com.dateplan.dateplan.global.exception.ErrorCode;
 import com.dateplan.dateplan.global.exception.NoPermissionException;
 import com.dateplan.dateplan.global.exception.S3Exception;
 import com.dateplan.dateplan.global.exception.S3ImageNotFoundException;
+import com.dateplan.dateplan.global.exception.couple.MemberNotConnectedException;
 import com.dateplan.dateplan.global.exception.member.AlreadyConnectedException;
 import com.dateplan.dateplan.global.exception.member.InvalidConnectionCodeException;
 import com.dateplan.dateplan.global.exception.member.SelfConnectionNotAllowedException;
@@ -500,6 +504,78 @@ public class MemberControllerTest extends ControllerTestSupport {
 		}
 	}
 
+	@Nested
+	@DisplayName("특정 회원의 프로필 이미지 조회 요청시")
+	class GetProfileImageURL {
+
+		private static final String REQUEST_URL = "/api/members/{member_id}/profile/image";
+
+		@DisplayName("로그인한 회원 자신 혹은 연결된 회원의 프로필 이미지 조회 요청이면 성공한다.")
+		@Test
+		void withLoginMemberIdOrPartnerMemberId() throws Exception {
+
+			// Stub
+			Member loginMember = createMember();
+			MemberThreadLocal.set(loginMember);
+			Long partnerId = 2L;
+			ProfileImageURLServiceResponse serviceResponse = createProfileImageURLServiceResponse();
+			given(coupleReadService.getPartnerId(any(Member.class)))
+				.willReturn(partnerId);
+			given(memberReadService.getProfileImageURL(anyLong(), anyLong()))
+				.willReturn(serviceResponse);
+
+			// When & Then
+			mockMvc.perform(get(REQUEST_URL, 1L))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value("true"))
+				.andExpect(jsonPath("$.data.profileImageURL").value(serviceResponse.getProfileImageURL()));
+		}
+
+		@DisplayName("다른 회원과 연결되지 않은 회원의 요청이면 에러 코드, 메시지를 응답한다.")
+		@Test
+		void withNotConnectedMember() throws Exception {
+
+			// Stub
+			Member loginMember = createMember();
+			MemberThreadLocal.set(loginMember);
+			MemberNotConnectedException expectedException = new MemberNotConnectedException();
+			given(coupleReadService.getPartnerId(any(Member.class)))
+				.willThrow(expectedException);
+
+			// When & Then
+			mockMvc.perform(get(REQUEST_URL, 1L))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.success").value("false"))
+				.andExpect(jsonPath("$.code").value(expectedException.getErrorCode().getCode()))
+				.andExpect(jsonPath("$.message").value(expectedException.getMessage()));
+		}
+
+		@DisplayName("로그인한 회원 및 연결된 회원에 대한 요청이 아니면 에러 코드, 메시지를 응답한다.")
+		@Test
+		void withNotLoginMemberIdAndPartnerMemberId() throws Exception {
+
+			// Stub
+			Member loginMember = createMember();
+			MemberThreadLocal.set(loginMember);
+
+			Long partnerId = 2L;
+			given(coupleReadService.getPartnerId(any(Member.class)))
+				.willReturn(partnerId);
+
+			NoPermissionException expectedException = new NoPermissionException(Resource.MEMBER,
+				Operation.READ);
+			given(memberReadService.getProfileImageURL(anyLong(), anyLong()))
+				.willThrow(expectedException);
+
+			// When & Then
+			mockMvc.perform(get(REQUEST_URL, 1L))
+				.andExpect(status().isForbidden())
+				.andExpect(jsonPath("$.success").value("false"))
+				.andExpect(jsonPath("$.code").value(expectedException.getErrorCode().getCode()))
+				.andExpect(jsonPath("$.message").value(expectedException.getMessage()));
+		}
+	}
+
 	private ConnectionServiceResponse createConnectionServiceResponse(String connectionCode) {
 		return ConnectionServiceResponse.builder()
 			.connectionCode(connectionCode)
@@ -530,6 +606,24 @@ public class MemberControllerTest extends ControllerTestSupport {
 			.birth(LocalDate.of(2020, 10, 10))
 			.gender(Gender.MALE)
 			.profileImageURL("imageURL")
+			.build();
+	}
+
+	private ProfileImageURLServiceResponse createProfileImageURLServiceResponse(){
+
+		return ProfileImageURLServiceResponse.builder()
+			.profileImageURL("profileImageURL")
+			.build();
+	}
+
+	private Member createMember() {
+
+		return Member.builder()
+			.name("홍길동")
+			.nickname("nickname")
+			.phone("01012341234")
+			.password("password")
+			.gender(Gender.FEMALE)
 			.build();
 	}
 }

--- a/src/test/java/com/dateplan/dateplan/service/couple/CoupleReadServiceTest.java
+++ b/src/test/java/com/dateplan/dateplan/service/couple/CoupleReadServiceTest.java
@@ -53,8 +53,8 @@ public class CoupleReadServiceTest extends ServiceTestSupport {
 
 		@BeforeEach
 		void setUp() {
-			Member member1 = createMember(phone1);
-			Member member2 = createMember(phone2);
+			Member member1 = createMember(phone1, "nickname1");
+			Member member2 = createMember(phone2, "nickname2");
 			memberRepository.save(member1);
 			memberRepository.save(member2);
 		}
@@ -104,9 +104,9 @@ public class CoupleReadServiceTest extends ServiceTestSupport {
 
 		@BeforeEach
 		void setUp() {
-			connectedMember1 = createMember("01011111111");
-			connectedMember2 = createMember("01022222222");
-			notConnectedMember = createMember("01033333333");
+			connectedMember1 = createMember("01011111111", "nickname1");
+			connectedMember2 = createMember("01022222222", "nickname2");
+			notConnectedMember = createMember("01033333333", "nickname3");
 			memberRepository.saveAll(
 				List.of(connectedMember1, connectedMember2, notConnectedMember));
 
@@ -168,9 +168,9 @@ public class CoupleReadServiceTest extends ServiceTestSupport {
 
 		@BeforeEach
 		void setUp() {
-			connectedMember1 = createMember("01012345678");
-			connectedMember2 = createMember("01012345679");
-			notConnectedMember = createMember("01012345670");
+			connectedMember1 = createMember("01012345678", "nickname1");
+			connectedMember2 = createMember("01012345679", "nickname2");
+			notConnectedMember = createMember("01012345670", "nickname3");
 			memberRepository.saveAll(
 				List.of(connectedMember1, connectedMember2, notConnectedMember));
 			Couple couple = Couple.builder()
@@ -225,8 +225,8 @@ public class CoupleReadServiceTest extends ServiceTestSupport {
 
 		@BeforeEach
 		void setUp() {
-			member1 = createMember("01012345678");
-			member2 = createMember("01012345679");
+			member1 = createMember("01012345678", "nickname1");
+			member2 = createMember("01012345679", "nickname2");
 			memberRepository.saveAll(List.of(member1, member2));
 			couple = coupleRepository.save(createCouple(member1, member2));
 			MemberThreadLocal.set(member1);
@@ -250,7 +250,8 @@ public class CoupleReadServiceTest extends ServiceTestSupport {
 		void failWithNotConnected() {
 
 			// Given
-			Member notConnectedMember = memberRepository.save(createMember("01011112222"));
+			Member notConnectedMember = memberRepository.save(
+				createMember("01011112222", "nickname3"));
 			MemberThreadLocal.set(notConnectedMember);
 
 			// When & Then
@@ -270,10 +271,11 @@ public class CoupleReadServiceTest extends ServiceTestSupport {
 
 		@BeforeEach
 		void setUp() {
-			connectedMember1 = createMember("01012345678");
-			connectedMember2 = createMember("01012345679");
-			notConnectedMember = createMember("01012345555");
-			memberRepository.saveAll(List.of(connectedMember1, connectedMember2, notConnectedMember));
+			connectedMember1 = createMember("01012345678", "nickname1");
+			connectedMember2 = createMember("01012345679", "nickname2");
+			notConnectedMember = createMember("01012345555", "nickname3");
+			memberRepository.saveAll(
+				List.of(connectedMember1, connectedMember2, notConnectedMember));
 			Couple couple = createCouple(connectedMember1, connectedMember2);
 			coupleRepository.save(couple);
 		}
@@ -308,11 +310,11 @@ public class CoupleReadServiceTest extends ServiceTestSupport {
 		}
 	}
 
-	private Member createMember(String phone) {
+	private Member createMember(String phone, String nickname) {
 
 		return Member.builder()
 			.name("name")
-			.nickname("nickname")
+			.nickname(nickname)
 			.phone(phone)
 			.password("password")
 			.gender(Gender.FEMALE)

--- a/src/test/java/com/dateplan/dateplan/service/couple/CoupleServiceTest.java
+++ b/src/test/java/com/dateplan/dateplan/service/couple/CoupleServiceTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
-import com.dateplan.dateplan.domain.couple.dto.CoupleInfoServiceResponse;
 import com.dateplan.dateplan.domain.couple.dto.FirstDateServiceRequest;
 import com.dateplan.dateplan.domain.couple.dto.FirstDateServiceResponse;
 import com.dateplan.dateplan.domain.couple.entity.Couple;
@@ -76,7 +75,7 @@ public class CoupleServiceTest extends ServiceTestSupport {
 
 		@BeforeEach
 		void setUp() {
-			member = memberRepository.save(createMember("01012345678"));
+			member = memberRepository.save(createMember("01012345678", "nickname"));
 			MemberThreadLocal.set(member);
 		}
 
@@ -220,8 +219,8 @@ public class CoupleServiceTest extends ServiceTestSupport {
 
 		@BeforeEach
 		void setUp() {
-			member = memberRepository.save(createMember("01012345678"));
-			oppositeMember = memberRepository.save(createMember("01012345679"));
+			member = memberRepository.save(createMember("01012345678", "nickname1"));
+			oppositeMember = memberRepository.save(createMember("01012345679", "nickname2"));
 			MemberThreadLocal.set(member);
 		}
 
@@ -368,8 +367,8 @@ public class CoupleServiceTest extends ServiceTestSupport {
 
 		@BeforeEach
 		void setUp() {
-			member1 = createMember("01012345678");
-			member2 = createMember("01012345679");
+			member1 = createMember("01012345678", "nickname1");
+			member2 = createMember("01012345679", "nickname2");
 			memberRepository.saveAll(List.of(member1, member2));
 			couple = coupleRepository.save(createCouple(member1, member2));
 			MemberThreadLocal.set(member1);
@@ -395,7 +394,7 @@ public class CoupleServiceTest extends ServiceTestSupport {
 		void failWithNotConnectedMember() {
 
 			// Given
-			Member nowConnectedMember = createMember("01011111111");
+			Member nowConnectedMember = createMember("01011111111", "nickname");
 			MemberThreadLocal.set(nowConnectedMember);
 			memberRepository.save(nowConnectedMember);
 
@@ -438,8 +437,8 @@ public class CoupleServiceTest extends ServiceTestSupport {
 
 		@BeforeEach
 		void setUp() {
-			member1 = createMember("01012345678");
-			member2 = createMember("01012345679");
+			member1 = createMember("01012345678", "nickname1");
+			member2 = createMember("01012345679", "nickname2");
 			memberRepository.saveAll(List.of(member1, member2));
 			couple = coupleRepository.save(createCouple(member1, member2));
 			MemberThreadLocal.set(member1);
@@ -467,7 +466,7 @@ public class CoupleServiceTest extends ServiceTestSupport {
 		void failWithNotConnectedMember() {
 
 			// Given
-			Member nowConnectedMember = createMember("01011111111");
+			Member nowConnectedMember = createMember("01011111111", "nickname");
 			MemberThreadLocal.set(nowConnectedMember);
 			memberRepository.save(nowConnectedMember);
 			FirstDateServiceRequest request = createFirstDateServiceRequest();
@@ -509,14 +508,14 @@ public class CoupleServiceTest extends ServiceTestSupport {
 			.build();
 	}
 
-	private Member createMember(String phone) {
+	private Member createMember(String phone, String nickname) {
 		return Member.builder()
 			.phone(phone)
 			.password("password")
 			.name("name")
 			.birth(LocalDate.now().minusDays(1L))
 			.gender(Gender.MALE)
-			.nickname("nickname")
+			.nickname(nickname)
 			.build();
 	}
 

--- a/src/test/java/com/dateplan/dateplan/service/member/AuthServiceTest.java
+++ b/src/test/java/com/dateplan/dateplan/service/member/AuthServiceTest.java
@@ -118,7 +118,7 @@ public class AuthServiceTest extends ServiceTestSupport {
 		void sendCodeWithExistsPhoneNumber() {
 
 			// Given
-			Member member = createMember("01012341234", "password");
+			Member member = createMember("01012341234", "password", "nickname");
 			memberRepository.save(member);
 
 			String phoneNumber = member.getPhone();
@@ -359,7 +359,7 @@ public class AuthServiceTest extends ServiceTestSupport {
 
 		@BeforeEach
 		void setUp() {
-			member = memberRepository.save(createMember(phone, password));
+			member = memberRepository.save(createMember(phone, password, "nickname1"));
 		}
 
 		@DisplayName("올바른 번호와 비밀번호를 입력하면 로그인에 성공하고, 레디스에 리프레시 토큰이 저장된다")
@@ -385,7 +385,7 @@ public class AuthServiceTest extends ServiceTestSupport {
 			// Given
 			String phone2 = "01012345679";
 
-			Member member2 = memberRepository.save(createMember(phone2, password));
+			Member member2 = memberRepository.save(createMember(phone2, password, "nickname2"));
 
 			LoginServiceRequest member1Request = createLoginServiceRequest(phone, password);
 			LoginServiceRequest member2Request = createLoginServiceRequest(phone2, password);
@@ -414,7 +414,7 @@ public class AuthServiceTest extends ServiceTestSupport {
 			// Given
 			String phone2 = "01012345679";
 
-			memberRepository.save(createMember(phone2, password));
+			memberRepository.save(createMember(phone2, password, "nickname2"));
 
 			LoginServiceRequest member1Request = createLoginServiceRequest(phone, password);
 			LoginServiceRequest member2Request = createLoginServiceRequest(phone2, password);
@@ -503,11 +503,11 @@ public class AuthServiceTest extends ServiceTestSupport {
 		return new PhoneAuthCodeServiceRequest(phone, code);
 	}
 
-	private Member createMember(String phone, String password) {
+	private Member createMember(String phone, String password, String nickname) {
 
 		return Member.builder()
 			.name("name")
-			.nickname("nickname")
+			.nickname(nickname)
 			.phone(phone)
 			.password(password)
 			.gender(Gender.FEMALE)

--- a/src/test/java/com/dateplan/dateplan/service/member/MemberServiceTest.java
+++ b/src/test/java/com/dateplan/dateplan/service/member/MemberServiceTest.java
@@ -237,7 +237,7 @@ public class MemberServiceTest extends ServiceTestSupport {
 
 		@BeforeEach
 		void setUp() {
-			loginMember = createMember();
+			loginMember = createMember("nickname");
 			memberRepository.save(loginMember);
 			MemberThreadLocal.set(loginMember);
 		}
@@ -323,7 +323,7 @@ public class MemberServiceTest extends ServiceTestSupport {
 
 		@BeforeEach
 		void setUp() {
-			loginMember = createMember();
+			loginMember = createMember("nickname1");
 			memberRepository.save(loginMember);
 			MemberThreadLocal.set(loginMember);
 		}
@@ -403,7 +403,8 @@ public class MemberServiceTest extends ServiceTestSupport {
 		void withNoPermission() {
 
 			// Given
-			Member targetMember = createMember("01000000000", "targetMemberProfileImageURL");
+			Member targetMember = createMember("01000000000", "nickname2",
+				"targetMemberProfileImageURL");
 			memberRepository.save(targetMember);
 
 			Long targetMemberId = targetMember.getId();
@@ -434,7 +435,7 @@ public class MemberServiceTest extends ServiceTestSupport {
 
 		@BeforeEach
 		void setUp() {
-			loginMember = createMember();
+			loginMember = createMember("nickname1");
 			memberRepository.save(loginMember);
 			MemberThreadLocal.set(loginMember);
 		}
@@ -508,7 +509,8 @@ public class MemberServiceTest extends ServiceTestSupport {
 		void withNoPermission() {
 
 			// Given
-			Member targetMember = createMember("01000000000", "targetMemberProfileImageURL");
+			Member targetMember = createMember("01000000000", "nickname2",
+				"targetMemberProfileImageURL");
 			memberRepository.save(targetMember);
 
 			Long targetMemberId = targetMember.getId();
@@ -531,11 +533,11 @@ public class MemberServiceTest extends ServiceTestSupport {
 		}
 	}
 
-	private Member createMember() {
+	private Member createMember(String nickname) {
 
 		return Member.builder()
 			.name("홍길동")
-			.nickname("nickname")
+			.nickname(nickname)
 			.phone("01012341234")
 			.password("password")
 			.gender(Gender.MALE)
@@ -543,11 +545,11 @@ public class MemberServiceTest extends ServiceTestSupport {
 			.build();
 	}
 
-	private Member createMember(String phone, String profileImageURL) {
+	private Member createMember(String phone, String nickname, String profileImageURL) {
 
 		Member member = Member.builder()
 			.name("홍길동")
-			.nickname("nickname")
+			.nickname(nickname)
 			.phone(phone)
 			.password("password")
 			.gender(Gender.MALE)


### PR DESCRIPTION
## 구현 목록
- 회원 프로필 이미지 조회
  - 단, 회원 자신과 연결된 회원의 프로필 이미지만 조회

## 테스트
- MemberController
<img width="644" alt="스크린샷 2023-06-12 18 38 01" src="https://github.com/couplog/back-end/assets/67905075/4e4f6097-23d7-49a9-a0a1-793b483db97e">

- MemberReadService
<img width="642" alt="스크린샷 2023-06-12 18 36 58" src="https://github.com/couplog/back-end/assets/67905075/586498b3-e3af-403b-b412-47b465e36796">

- CoupleReadService
<img width="664" alt="스크린샷 2023-06-12 18 37 41" src="https://github.com/couplog/back-end/assets/67905075/e260ddfc-db62-4b64-88f3-2732c5038e1f">

this closes #55 