### PR TITLE
Feat/#96 커플 기념일 삭제

### DIFF
--- a/src/main/java/com/dateplan/dateplan/domain/anniversary/controller/AnniversaryController.java
+++ b/src/main/java/com/dateplan/dateplan/domain/anniversary/controller/AnniversaryController.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.DateTimeFormat.ISO;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -104,6 +105,19 @@ public class AnniversaryController {
 
 		anniversaryService.modifyAnniversary(loginMember, coupleId, anniversaryId,
 			request.toServiceRequest());
+
+		return ApiResponse.ofSuccess();
+	}
+
+	@DeleteMapping("/{anniversary_id}")
+	public ApiResponse<Void> deleteAnniversary(
+		@PathVariable("couple_id") Long coupleId,
+		@PathVariable("anniversary_id") Long anniversaryId
+	) {
+
+		Member loginMember = MemberThreadLocal.get();
+
+		anniversaryService.deleteAnniversary(loginMember, coupleId, anniversaryId);
 
 		return ApiResponse.ofSuccess();
 	}

--- a/src/main/java/com/dateplan/dateplan/domain/anniversary/repository/AnniversaryRepository.java
+++ b/src/main/java/com/dateplan/dateplan/domain/anniversary/repository/AnniversaryRepository.java
@@ -2,7 +2,13 @@ package com.dateplan.dateplan.domain.anniversary.repository;
 
 import com.dateplan.dateplan.domain.anniversary.entity.Anniversary;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface AnniversaryRepository extends JpaRepository<Anniversary, Long> {
 
+	@Modifying
+	@Query("DELETE FROM Anniversary a WHERE a.anniversaryPattern.id = :anniversaryPatternId")
+	void deleteAllByAnniversaryPatternId(@Param("anniversaryPatternId") Long anniversaryPatternId);
 }

--- a/src/main/java/com/dateplan/dateplan/domain/anniversary/service/AnniversaryService.java
+++ b/src/main/java/com/dateplan/dateplan/domain/anniversary/service/AnniversaryService.java
@@ -220,5 +220,28 @@ public class AnniversaryService {
 			request.getContent(), request.getDate());
 	}
 
+	public void deleteAnniversary(Member loginMember, Long coupleId, Long anniversaryId) {
+
+		Couple couple = coupleReadService.findCoupleByMemberOrElseThrow(loginMember);
+
+		if (!Objects.equals(couple.getId(), coupleId)) {
+			throw new NoPermissionException(Resource.ANNIVERSARY, Operation.DELETE);
+		}
+
+		Anniversary anniversary = anniversaryReadService.findAnniversaryByIdOrElseThrow(
+			anniversaryId, true);
+
+		AnniversaryPattern anniversaryPattern = anniversary.getAnniversaryPattern();
+
+		Long anniversaryOwnerCoupleId = anniversaryPattern.getCouple().getId();
+
+		if (!Objects.equals(anniversaryOwnerCoupleId, coupleId) ||
+			!Objects.equals(anniversary.getCategory(), AnniversaryCategory.OTHER)
+		) {
+			throw new NoPermissionException(Resource.ANNIVERSARY, Operation.UPDATE);
+		}
+
+		anniversaryRepository.deleteAllByAnniversaryPatternId(anniversaryPattern.getId());
+	}
 
 }


### PR DESCRIPTION
## 구현 목록
- 커플 기념일 삭제(연관된 반복 기념일도 모두 삭제)
- 이 때, 처음만난날, 생일 관련 기념일은 삭제 불가능

## 테스트 목록
- AnniversaryService
<img width="733" alt="스크린샷 2023-07-05 15 43 19" src="https://github.com/couplog/back-end/assets/67905075/d08e8cbc-baef-46ee-8011-ec2b71292919">

- AnniversaryController
<img width="794" alt="스크린샷 2023-07-05 15 44 23" src="https://github.com/couplog/back-end/assets/67905075/6386b239-fecf-4244-b755-b51ebe47e076">
